### PR TITLE
Replace MacOS.prefer_64_bit with Hardware::CPU.is_64_bit.

### DIFF
--- a/terraform.rb
+++ b/terraform.rb
@@ -61,7 +61,7 @@ class Terraform < Formula
       # system "go", "test", *terraform_files
 
       mkdir "bin"
-      arch = MacOS.prefer_64_bit? ? "amd64" : "386"
+      arch = Hardware::CPU.is_64_bit? ? "amd64" : "386"
       system "gox",
         "-arch", arch,
         "-os", "darwin",


### PR DESCRIPTION
**Test:**
```
brew install https://raw.githubusercontent.com/Ensighten/homebrew-formulae/TOP-2076_64-bit-check/terraform.rb

...

==> go build
==> gox -arch amd64 -os darwin -output bin/terraform-{{.Dir}} github.com/hashicorp/terraform github.com/hashicorp/terraform/builtin/bins/provider-atlas github.com/hashicorp/terraform/builtin/bins/provider-aws github.com/hashicorp/terraform/builtin/bins/provider-azure github.com/hashicorp/terraform/builtin/bins/prov

...

==> Summary
🍺  /usr/local/Cellar/terraform/0.6.16-ens.20: 48 files, 733.5MB, built in 1 minute 23 seconds
```